### PR TITLE
Fix typos in comments and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ SwiftyStats is a framework written entirely in Swift that makes heavy use of gen
 > It is a framework that is regularly developed and has been created out of passion rather than necessity.
 
 # New in version 1.1.7
-* some less typos
-* parameters for Poisson and Binomial distribution
+* fewer typos
+* parameters for Poisson and Binomial distributions
 * refactoring
 
 # Important
@@ -27,22 +27,22 @@ The following "namespaces"/classes are provided (among others):
 * [`SSExamine`](docs/Classes/SSExamine.html) (class)
 * [`SSHypothesisTesting`](docs/Enums/SSHypothesisTesting.html) (enum)
 * [`SSProbDist`](docs/Enums/SSProbDist.html) (enum)
-* [`SSDataFrame`](docs/Classes/SSDataFrame.html) instances encapsulate datasets. You can imagine the structure of an `SSDataFrame` object as a table: The columns of the table correspond to the individual dataset and the rows correspond to the data of the dataset.
-* [`SSCrossTab`](docs/Structures/SSCrossTab.html) contains a cross table with the usual structure (like a n x m matrix) and provides the statistics needed for frequency comparisons (Chi-square, Phi, residuals etc.).
+* [`SSDataFrame`](docs/Classes/SSDataFrame.html) instances encapsulate datasets. You can imagine the structure of an `SSDataFrame` object as a table: The columns of the table correspond to the individual datasets and the rows correspond to their data.
+* [`SSCrossTab`](docs/Structures/SSCrossTab.html) contains a cross table with the usual structure (like an n x m matrix) and provides the statistics needed for frequency comparisons (Chi-square, Phi, residuals etc.).
 
-There are several extensions to standard Swift types (`Array`, Floating point types, `String `).
+There are several extensions to standard Swift types (`Array`, floating-point types, `String`).
 
 # Using Xcode
 
 The attached Xcode project contains four targets:
 > * SwiftyStats (for macOS)
 > * SwiftyStatsMobile (for iOS)
-> * SwiftyStatsTests (Testsuite)
+> * SwiftyStatsTests (test suite)
 > * SwiftStatsCLTest (a command line demo)
 
 *Each target must be built individually (i.e. no dependencies are defined)!*
 
-In addition a Playground is added to
+In addition, a Playground is included to:
 > * test the framework and 
 > * do prototyping
 
@@ -50,14 +50,14 @@ In addition a Playground is added to
 Due to the extensive support of generic types, the type checker runs hot and takes a long time to compile. Therefore the code doesn't look "nice" in some places, because "complex" expressions (like `(z1 + z1 - w) / (z1 * w)`) had to be simplified.
 
 # How to Install
-## CocoaPods (recommended if your are on a Mac)
+## CocoaPods (recommended if you are on a Mac)
 [CocoaPods](http://cocoapods.org) is the preferred way to add SwiftyStats to your project:
 
 ```bash
 $> cd <YOUR_PROJECT_FOLDER>
 $> vi Podfile
 ```
-Your Podfile should looks like:  
+Your Podfile should look like:
 
 ```ruby
 target 'YOURPROJECT' do
@@ -65,7 +65,7 @@ use_frameworks!
 pod 'SwiftyStats'  
 end
 ```
-If you have to use a Swift version **earlier** than 4.2, replace the line `pod 'SwiftyStats'` by:
+If you have to use a Swift version **earlier** than 4.2, replace the line `pod 'SwiftyStats'` with:
 
 ```ruby
 ...
@@ -227,7 +227,7 @@ Probability distributions in general are defined within relatively narrow condit
 * columnSum(columnName:)
 * total
 * rowTotal()
-* colummTotal()
+* columnTotal()
 * largestRowTotal()
 * largestCellCount(atColumn:)
 * largestCellCount(atRow:)
@@ -258,7 +258,7 @@ Probability distributions in general are defined within relatively narrow condit
 * r0
 * r1 
 
-#### Probability Functions (cdf, pdf, quantile, para - see above)
+#### Probability Functions (cdf, pdf, quantile, parameters - see above)
 
 * Beta
 * Binomial
@@ -287,12 +287,12 @@ Probability distributions in general are defined within relatively narrow condit
 
 #### SSHypothesisTesting
 
-#####Equality of means
+##### Equality of means
 
 * twoSampleTTest(data1:data2:alpha:)
 * twoSampleTTest(sample1:sample2:alpha:)
 * oneSampleTTest(sample:mean:alpha:)
-* oneSampleTTEst(data:mean:alpha:)
+* oneSampleTTest(data:mean:alpha:)
 * matchedPairsTTest(set1:set2:alpha:)
 * matchedPairsTTest(data1:data2:alpha:)
 * oneWayANOVA(data:alpha:)
@@ -306,12 +306,12 @@ Probability distributions in general are defined within relatively narrow condit
 * scheffeTest(dataFrame:alpha:)
 * bonferroniTest(dataFrame:)
 
-#####Autocorrelation
+##### Autocorrelation
 
 * autocorrelationCoefficient(array:lag:)
 * autocorrelation(array:)
 
-#####NPAR tests
+##### NPAR tests
 
 * ksGoFTest(array:targetDistribution:)
 * adNormalityTest(data:alpha:)
@@ -325,16 +325,16 @@ Probability distributions in general are defined within relatively narrow condit
 * waldWolfowitzTwoSampleTest(set1:set2:)
 * kruskalWallisHTest(data:alpha:)
 
-#####Outliers
+##### Outliers
 
 * grubbsTest(array:alpha:)
 * esdOutlierTest(array:alpha:maxOutliers:testType:)
 
-#####Randomness
+##### Randomness
 
 * runsTest(array:alpha:useCuttingPoint:userDefinedCuttingPoint:alternative:)
 
-#####Equality of variances
+##### Equality of variances
 
 * bartlettTest(array:alpha:)
 * leveneTest(array:testType:alpha:)

--- a/SwiftyStats/CommonSource/HypothesisTesting/SSHypothesisTesting-NPAR.swift
+++ b/SwiftyStats/CommonSource/HypothesisTesting/SSHypothesisTesting-NPAR.swift
@@ -27,8 +27,8 @@ import Foundation
 import os.log
 #endif
 
-/// Implenets some of the more often used non-parametreic test.
-/// Non-parametric tests are constructed to analyze data, which are not unederlying a speiciic ditrisbution.
+/// Implements some of the more commonly used non-parametric tests.
+/// Non-parametric tests are designed to analyze data that do not follow a specific distribution.
 extension SSHypothesisTesting {
 
     /// Performs the goodness of fit test according to Kolmogorov and Smirnov

--- a/SwiftyStats/CommonSource/SpecialFunctions/Hypergeo/HypergeometricPFQ.swift
+++ b/SwiftyStats/CommonSource/SpecialFunctions/Hypergeo/HypergeometricPFQ.swift
@@ -99,20 +99,20 @@ extension SSSpecialFunctions {
      %     *     are p and q in the pFq function).                        *
      %     *  3. Double precision complex argument Z.                     *
      %     *  4. Integer LNPFQ.  This integer should be set to '1' if the *
-     %     *     result from PFQ is to be returned as the natural logaritm*
+     %     *     result from PFQ is to be returned as the natural logarithm*
      %     *     of the series, or '0' if not.  The user can generally set*
      %     *     LNPFQ = '0' and change it if required.                   *
      %     *  5. Integer IX.  This integer should be set to '0' if the    *
      %     *     user desires the program PFQ to estimate the number of   *
      %     *     array terms (in A and B) to be used, or an integer       *
      %     *     greater than zero specifying the number of integer pos-  *
-     %     *     itions to be used.  This input parameter is escpecially  *
+     %     *     itions to be used.  This input parameter is especially  *
      %     *     useful as a means to check the results of a given run.   *
-     %     *     Specificially, if the user obtains a result for a given  *
+     %     *     Specifically, if the user obtains a result for a given  *
      %     *     set of parameters, then changes IX and re-runs the eval- *
      %     *     uator, and if the number of array positions was insuffi- *
-     %     *     cient, then the two results will likely differ.  The rec-*
-     %     *     commended would be to generally set IX = '0' and then set*
+     %     *     cient, then the two results will likely differ.  It is   *
+     %     *     recommended to generally set IX = '0' and then set      *
      %     *     it to 100 or so for a second run.  Note that the LENGTH  *
      %     *     parameter currently sets the upper limit on IX to 777,   *
      %     *     but that can easily be changed (it is a single PARAMETER *
@@ -125,7 +125,7 @@ extension SSSpecialFunctions {
      %     *                                                              *
      %     *     Note: The variable NOUT is the file to which error mess- *
      %     *           ages are written (default is 6).  This can be      *
-     %     *           changed in the FUNCTION PFQ to accomodate re-      *
+     %     *           changed in the FUNCTION PFQ to accommodate re-     *
      %     *           of output to another file                          *
      %     *                                                              *
      %     *  Subprograms called: HYPER.                                  *


### PR DESCRIPTION
## Summary
- correct README grammar and spelling
- fix typos in non-parametric test comment
- improve hypergeometric function documentation

## Testing
- `make test` *(fails: no such module 'Accelerate.vecLib.LinearAlgebra')*

------
https://chatgpt.com/codex/tasks/task_e_6899a47be1ec832abc9906ff0d8285dc